### PR TITLE
Always send back a PUBCOMP

### DIFF
--- a/src/paho/mqtt/client.py
+++ b/src/paho/mqtt/client.py
@@ -2535,9 +2535,7 @@ class Client(object):
                         if rc != MQTT_ERR_SUCCESS:
                             return rc
 
-                    return self._send_pubcomp(mid)
-
-        return MQTT_ERR_SUCCESS
+        return self._send_pubcomp(mid)
 
     def _update_inflight(self):
         # Dont lock message_mutex here


### PR DESCRIPTION
See #284

Not sure if this is truly correct or introduces unexpected behavior or not but it does prevent a persistent session from getting stuck if you're resuming a persistent session and don't have state stored.